### PR TITLE
Performance imrovements

### DIFF
--- a/plugin/unused-imports.vim
+++ b/plugin/unused-imports.vim
@@ -34,8 +34,8 @@ function! s:highlight_unused_imports(remove)
     let lis = matchlist(line, '\v^\s*import\s+(\w+\.)+(\w+);')
     if len(lis) > 0
       let s = lis[2]
-      let searchStr = '\v(//.*)@<!(^\s*import\s+.*)@<!<' . s . '>'
-      let linefound = search(searchStr, 'nw')
+      let searchPattern = '\v(//.*)@<!(^\s*import\s+.*)@<!<' . s . '>'
+      let linefound = search(searchPattern, 'nw')
       if linefound == 0
         if a:remove
           exec linenr . 'd _'

--- a/plugin/unused-imports.vim
+++ b/plugin/unused-imports.vim
@@ -43,11 +43,11 @@ function! s:highlight_unused_imports(remove)
     let lis = matchlist(line, '\v^\s*import\s+(\w+\.)+(\w+);')
     if len(lis) > 0
       let s = lis[2]
-      let searchPattern = '\v(//.*)@<!(^\s*import\s+.*)@<!<' . s . '>'
+      let searchPattern = '\v(//.*)@<!<' . s . '>'
 
       " start searching from the class definition
       call cursor(classStartLine, 1)
-      let linefound = search(searchPattern, 'nw')
+      let linefound = search(searchPattern, 'nW')
 
       if linefound == 0
         if a:remove

--- a/plugin/unused-imports.vim
+++ b/plugin/unused-imports.vim
@@ -26,8 +26,17 @@ let s:matches_so_far = []
 
 function! s:highlight_unused_imports(remove)
   call s:reset_unused_highlights()
-  let linenr = 0
   highlight unusedimport ctermbg=darkred guibg=darkred
+
+  " save current position to set it back later
+  let startLine = line(".")
+  let startCol = col(".")
+
+  let linenr = 0
+  " where does the class definition start (= where the imports end)
+  call cursor(1, 1)
+  let classStartLine = search('\v(^\s*import\s+)@<!<class>')
+
   while linenr < line("$")
     let linenr += 1
     let line = getline(linenr)
@@ -35,7 +44,11 @@ function! s:highlight_unused_imports(remove)
     if len(lis) > 0
       let s = lis[2]
       let searchPattern = '\v(//.*)@<!(^\s*import\s+.*)@<!<' . s . '>'
+
+      " start searching from the class definition
+      call cursor(classStartLine, 1)
       let linefound = search(searchPattern, 'nw')
+
       if linefound == 0
         if a:remove
           exec linenr . 'd _'
@@ -45,6 +58,9 @@ function! s:highlight_unused_imports(remove)
       endif
     endif
   endwhile
+
+  " set cursor back to initial position
+  call cursor(startLine, startCol)
 endfunction
 
 function! s:reset_unused_highlights()

--- a/plugin/unused-imports.vim
+++ b/plugin/unused-imports.vim
@@ -37,7 +37,7 @@ function! s:highlight_unused_imports(remove)
   call cursor(1, 1)
   let classStartLine = search('\v(^\s*import\s+)@<!<class>')
 
-  while linenr < line("$")
+  while linenr < classStartLine
     let linenr += 1
     let line = getline(linenr)
     let lis = matchlist(line, '\v^\s*import\s+(\w+\.)+(\w+);')


### PR DESCRIPTION
Hey,

I was opening a big java file and it seemed very slow to open, so I did some profiling. I used the tomcat repo as reference (https://github.com/apache/tomcat) and more specifically the PoolUtils.java (https://github.com/apache/tomcat/blob/trunk/java/org/apache/tomcat/dbcp/pool2/PoolUtils.java) - 1801 LOC, and StandardContext.java (https://github.com/apache/tomcat/blob/trunk/java/org/apache/catalina/core/StandardContext.java) - 6754 LOC

Running the following,
```bash
vim --cmd 'profile start profile.log' --cmd 'profile func *' --cmd 'profile file *' ./java/org/apache/tomcat/dbcp/pool2/PoolUtils.java
vim --cmd 'profile start profile.log' --cmd 'profile func *' --cmd 'profile file *' ./java/org/apache/catalina/core/StandardContext.java
```
I get these results (in seconds):
```
PoolUtils.java:
FUNCTION  <SNR>23_highlight_unused_imports()
Called 1 time
Total time:   4.864608
 Self time:   4.864572

StandardContext.java:
FUNCTION  <SNR>23_highlight_unused_imports()
Called 1 time
Total time:  53.421890
 Self time:  53.421856
```
So yes, that's pretty bad. With this pull request, I managed to improve the performance to be
```
PoolUtils.java:
FUNCTION  <SNR>23_highlight_unused_imports()
Called 1 time
Total time:   0.073792
 Self time:   0.073753

StandardContext.java:
FUNCTION  <SNR>23_highlight_unused_imports()
Called 1 time
Total time:   0.762480
 Self time:   0.762448

```

which is much better :) 
Let me know if you agree with this PR.

Cheers,

David 