### PR TITLE
Change class definition regex to consider annotations

### DIFF
--- a/plugin/unused-imports.vim
+++ b/plugin/unused-imports.vim
@@ -35,7 +35,7 @@ function! s:highlight_unused_imports(remove)
   let linenr = 0
   " where does the class definition start (= where the imports end)
   call cursor(1, 1)
-  let classStartLine = search('\v(^\s*import\s+)@<!<class>')
+  let classStartLine = search('\v(^\s*import\s+)@<!(<class>|\@)')
 
   while linenr < classStartLine
     let linenr += 1


### PR DESCRIPTION
Hey,

Here's another fix to take into consideration class annotations.
Example:
```
import javax.jws.WebService;

@WebService
public class MyWebService {..}
```
Cheers,

David