### PR TITLE
make highlight customizable

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -18,4 +18,8 @@ In normal mode:
     :UnusedImportsReset " clear the highlights
     :UnusedImportsRemove " remove all unused imports
 
+## Customize highlight ##
+
+    highlight unusedimport ctermbg=DarkRed ctermfg=White guibg=#8b0000 guifg=#ffffff
+
 This software is provided as-is, without any warranty whatsoever.

--- a/plugin/unused-imports.vim
+++ b/plugin/unused-imports.vim
@@ -22,7 +22,7 @@ if v:version < 700
     finish
 endif
 
-highlight default unusedimport ctermbg=DarkRed guibg=DarkRed
+highlight default link unusedimport Error
 let s:matches_so_far = []
 
 function! s:highlight_unused_imports(remove)

--- a/plugin/unused-imports.vim
+++ b/plugin/unused-imports.vim
@@ -22,11 +22,11 @@ if v:version < 700
     finish
 endif
 
+highlight default unusedimport ctermbg=DarkRed guibg=DarkRed
 let s:matches_so_far = []
 
 function! s:highlight_unused_imports(remove)
   call s:reset_unused_highlights()
-  highlight unusedimport ctermbg=darkred guibg=darkred
 
   " save current position to set it back later
   let startLine = line(".")


### PR DESCRIPTION
Current highlight doesn't override foreground color and sets background color as `darkred`. But depending on color theme it might be not dark enough and hard to read. So it's better if user could customize the highlight. 
This PR doesn't change default highlight, but I think it might be better to link default highlight to some existing group, so it would be guaranteed to look good. This is how I will override it in my vimrc:
```
highlight link unusedimport Comment
```
and it's similar to the way IntelliJ IDEA does:
![99F9813E5C3DE6E922](https://user-images.githubusercontent.com/4832334/91022833-b522d900-e630-11ea-856c-a2c240d20900.jpeg)
Should we change default highlight to something else?
